### PR TITLE
Fix deprecation note on SF >=2.7

### DIFF
--- a/BotDetector.php
+++ b/BotDetector.php
@@ -89,12 +89,11 @@ class BotDetector implements BotDetectorInterface
         $cache = new ConfigCache($this->options['cache_dir'] . '/' . $this->options['metadata_cache_file'], $this->options['debug']);
 
         if ($cache->isFresh()) {
-            if (method_exists($cache, '__toString')) {
-                // ConfigCache Symfony < 3.0 syntax.
-                return $this->metadatas = require $cache;
+            if (method_exists($cache, 'getPath')) {
+                return $this->metadatas = require $cache->getPath();
             }
-
-            return $this->metadatas = require $cache->getPath();
+            // ConfigCache Symfony < 2.7 syntax.
+            return $this->metadatas = require $cache;
         }
 
         /** @var $metadataCollection \Vipx\BotDetect\Metadata\MetadataCollection */


### PR DESCRIPTION
When running the symfony2 branch >=2.7 a deprecation note is triggered because existence of __toString method is checked. Better would be to check for getPath method and use it if available. Eases the migration to SF 3.0 regarding deprecations :) .

This PR reverses the check.